### PR TITLE
backup file should only be readable by owner

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -61,6 +61,7 @@ cp /etc/passbolt/gpg/serverkey.asc $backup_dir_date/.
 echo "Creating archive of $backup_dir_date"
 echo "+------------------------------------------------------------------------------------------+"
 tar -czvf $backup_dir_date.tar.gz -C $backup_dir_date .
+chmod 0600 $backup_dir_date.tar.gz
 echo "+------------------------------------------------------------------------------------------+"
 echo "Cleaning up $backup_dir"
 echo "+------------------------------------------------------------------------------------------+"


### PR DESCRIPTION
Backup includes private key and passwords, so the archive should only be readable by the owner.