### PR TITLE
Export $backup_file var for runing ouside purposes

### DIFF
--- a/backup.sh
+++ b/backup.sh
@@ -15,7 +15,7 @@ fi
 backup_dir="/tmp"
 # If you want to change how the date is displayed edit this line
 backup_dir_date=$backup_dir/backup-$(date +"%Y-%m-%d--%H-%M-%S")
-backup_file=$backup_dir/backup-$(date +"%Y-%m-%d--%H-%M-%S").tar.gz
+export backup_file=$backup_dir/backup-$(date +"%Y-%m-%d--%H-%M-%S").tar.gz
 
 
 if [ -f /.dockerenv ]


### PR DESCRIPTION
This change makes $backup_file variable able to reused from outside scripts, that runs backup.sh.

I'm using this repo as git submodule, to have most resent version of this script in my backup solution for passbolt, that creates and storing the backup. It would be great to have information about location of the backup tar archive after backup.sh execution.